### PR TITLE
Add full coverage tests for DateTime and TimeSpan extensions

### DIFF
--- a/Tests/Corlib.Tests/System/DateTimeAdditionalTests.cs
+++ b/Tests/Corlib.Tests/System/DateTimeAdditionalTests.cs
@@ -1,0 +1,87 @@
+using NUnit.Framework;
+
+namespace System;
+
+[TestFixture]
+public class DateTimeAdditionalTests {
+  [Test]
+  public void StartAndEndOfDay_ReturnExpectedValues() {
+    var sample = new DateTime(2024, 1, 3, 10, 30, 15);
+    Assert.AreEqual(new DateTime(2024, 1, 3, 0, 0, 0), sample.StartOfDay());
+    Assert.AreEqual(new DateTime(2024, 1, 3).AddDays(1).AddTicks(-1), sample.EndOfDay());
+  }
+
+  [Test]
+  public void AddWeeks_AddsSevenDaysForEachWeek() {
+    var date = new DateTime(2024, 1, 1);
+    Assert.AreEqual(new DateTime(2024, 1, 15), date.AddWeeks(2));
+  }
+
+  [Test]
+  public void DateOfDayOfCurrentWeek_ReturnsCorrectDate() {
+    var date = new DateTime(2024, 1, 3); // Wednesday
+    var monday = date.DateOfDayOfCurrentWeek(DayOfWeek.Monday);
+    Assert.AreEqual(new DateTime(2024, 1, 1).EndOfDay(), monday);
+  }
+
+  [Test]
+  public void FirstAndLastDayOfMonthAndYear() {
+    var date = new DateTime(2024, 5, 20);
+    Assert.AreEqual(new DateTime(2024, 5, 1), date.FirstDayOfMonth());
+    Assert.AreEqual(new DateTime(2024, 5, 31), date.LastDayOfMonth());
+    Assert.AreEqual(new DateTime(2024, 1, 1), date.FirstDayOfYear());
+    Assert.AreEqual(new DateTime(2024, 12, 31), date.LastDayOfYear());
+  }
+
+  [Test]
+  public void UnixConversionRoundTrip() {
+    var date = new DateTime(2024, 8, 18, 12, 0, 0, DateTimeKind.Utc);
+    var ticks = date.AsUnixTicksUtc();
+    var recon = DateTimeExtensions.FromUnixTicks(ticks, DateTimeKind.Utc);
+    Assert.AreEqual(date, recon);
+  }
+
+  [Test]
+  public void MaxMin_ReturnCorrectInstance() {
+    var early = new DateTime(2024, 1, 1);
+    var late = new DateTime(2024, 1, 2);
+    Assert.AreEqual(late, early.Max(late));
+    Assert.AreEqual(late, late.Max(early));
+    Assert.AreEqual(early, early.Min(late));
+    Assert.AreEqual(early, late.Min(early));
+  }
+
+  [Test]
+  public void DaysTill_ReturnsInclusiveRange() {
+    var start = new DateTime(2024, 1, 1);
+    var end = new DateTime(2024, 1, 4);
+    var expected = new[] {
+      new DateTime(2024, 1, 1),
+      new DateTime(2024, 1, 2),
+      new DateTime(2024, 1, 3),
+      new DateTime(2024, 1, 4)
+    };
+    CollectionAssert.AreEqual(expected, start.DaysTill(end));
+  }
+
+  [Test]
+  public void SubstractHelpers_SubtractCorrectAmounts() {
+    var date = new DateTime(2024, 1, 10, 10, 10, 10, DateTimeKind.Utc);
+    Assert.AreEqual(date.AddTicks(-5), date.SubstractTicks(5));
+    Assert.AreEqual(date.AddMilliseconds(-5), date.SubstractMilliseconds(5));
+    Assert.AreEqual(date.AddSeconds(-5), date.SubstractSeconds(5));
+    Assert.AreEqual(date.AddMinutes(-5), date.SubstractMinutes(5));
+    Assert.AreEqual(date.AddHours(-5), date.SubstractHours(5));
+    Assert.AreEqual(date.AddDays(-5), date.SubstractDays(5));
+    Assert.AreEqual(date.AddWeeks(-1), date.SubstractWeeks(1));
+    Assert.AreEqual(date.AddMonths(-1), date.SubstractMonths(1));
+    Assert.AreEqual(date.AddYears(-1), date.SubstractYears(1));
+  }
+
+  [Test]
+  public void UnixMillisecondsAndSecondsConversions() {
+    var date = new DateTime(1970, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+    Assert.AreEqual(86400000, date.AsUnixMillisecondsUtc());
+    Assert.AreEqual(date, DateTimeExtensions.FromUnixSeconds(86400, DateTimeKind.Utc));
+  }
+}

--- a/Tests/Corlib.Tests/System/TimeSpanExtensionsTests.cs
+++ b/Tests/Corlib.Tests/System/TimeSpanExtensionsTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using System.Diagnostics;
+
+namespace System;
+
+[TestFixture]
+public class TimeSpanExtensionsTests {
+  [Test]
+  public void NumericExtensionMethods_CreateExpectedTimeSpans() {
+    Assert.AreEqual(TimeSpan.FromSeconds(5), 5.Seconds());
+    Assert.AreEqual(TimeSpan.FromMinutes(2), 2.Minutes());
+    Assert.AreEqual(TimeSpan.FromHours(3), 3.Hours());
+    Assert.AreEqual(TimeSpan.FromDays(4), 4.Days());
+    Assert.AreEqual(TimeSpan.FromMilliseconds(150), 150.Milliseconds());
+    Assert.AreEqual(TimeSpan.FromDays(14), 2.Weeks());
+    Assert.AreEqual(TimeSpan.FromSeconds(1.5), 1.5.Seconds());
+    Assert.AreEqual(TimeSpan.FromDays(0.5), 0.5.Days());
+  }
+
+  [Test]
+  public void MultiplyAndDivideTimeSpan_ReturnsExpectedValue() {
+    var ts = TimeSpan.FromSeconds(10);
+    Assert.AreEqual(TimeSpan.FromSeconds(30), ts.MultipliedWith(3));
+    Assert.AreEqual(TimeSpan.FromSeconds(2), ts.DividedBy(5));
+  }
+
+  [Test]
+  public void DivideByTimeSpan_ReturnsDoubleRatio() {
+    var ts1 = TimeSpan.FromSeconds(10);
+    var ts2 = TimeSpan.FromSeconds(2);
+    Assert.AreEqual(5.0, ts1.DividedBy(ts2));
+  }
+
+  [Test]
+  public void FromNow_AddsSpanToCurrentTime() {
+    var span = TimeSpan.FromMilliseconds(100);
+    var expected = DateTime.Now + span;
+    var result = span.FromNow();
+    Assert.That(result - expected, Is.LessThan(TimeSpan.FromMilliseconds(20)));
+  }
+
+  [Test]
+  public void FromUtcNow_AddsSpanToCurrentUtcTime() {
+    var span = TimeSpan.FromMilliseconds(100);
+    var expected = DateTime.UtcNow + span;
+    var result = span.FromUtcNow();
+    Assert.That(result - expected, Is.LessThan(TimeSpan.FromMilliseconds(20)));
+  }
+
+  [Test]
+  public void StopwatchAndIterationHelpers_WorkAsExpected() {
+    var span = TimeSpan.FromMilliseconds(50);
+    var before = Stopwatch.GetTimestamp();
+    var timestamp = span.FromStopwatchTimeStamp();
+    var expectedAdvance = span.TotalSeconds * Stopwatch.Frequency;
+    Assert.That(Math.Abs(timestamp - before - expectedAdvance), Is.LessThan(Stopwatch.Frequency * 0.01));
+
+    var iteration = span.CurrenIteration();
+    var calc = Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency / span.TotalSeconds;
+    Assert.That(Math.Abs(iteration - calc), Is.LessThan(0.1));
+
+    var mod = span.CurrenIteration(5);
+    Assert.That(mod, Is.GreaterThanOrEqualTo(0).And.LessThan(5));
+
+    var drift = span.CurrenDrift();
+    var expectedFraction = iteration - Math.Floor(iteration);
+    Assert.That(Math.Abs(drift.TotalSeconds - expectedFraction), Is.LessThan(0.1));
+  }
+}


### PR DESCRIPTION
## Summary
- expand DateTime extension test coverage
- add TimeSpan stopwatch and iteration tests
- run the test suite (fails: NETSDK1045 - .NET 9.0 target not supported)

## Testing
- `dotnet test Tests/Corlib.Tests/Corlib.Tests.csproj -f net8.0 --verbosity normal` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_68862e4872b8833396f619d0aaad577c